### PR TITLE
Let async functions return invisibly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # coro (development version)
 
+* Async functions created by `coro::async()` now return their
+  `promises::promise()` invisibly (#46, @shikokuchuo).
+
 # coro 1.0.4
 
 * Internal fix for R-devel.

--- a/R/async.R
+++ b/R/async.R
@@ -27,7 +27,7 @@
 #'
 #' @param fn An anonymous function within which `await()` calls are
 #'   allowed.
-#' @return A function that returns a [promises::promise()].
+#' @return A function that returns a [promises::promise()] invisibly.
 #'
 #' @seealso [async_generator()] and [await_each()];
 #'   [coro_debug()] for step-debugging.

--- a/R/generator.R
+++ b/R/generator.R
@@ -208,7 +208,7 @@ generator0 <- function(fn, type = "generator") {
 
       if (is_string(type, "async")) {
         # Step into the generator right away
-        instance(NULL)
+        invisible(instance(NULL))
       } else {
         structure(instance, class = "coro_generator_instance")
       }

--- a/man/async.Rd
+++ b/man/async.Rd
@@ -16,7 +16,7 @@ allowed.}
 \item{x}{An awaitable value, i.e. a \link[promises:promise]{promise}.}
 }
 \value{
-A function that returns a \code{\link[promises:promise]{promises::promise()}}.
+A function that returns a \code{\link[promises:promise]{promises::promise()}} invisibly.
 }
 \description{
 \code{async()} functions are building blocks for cooperative

--- a/tests/testthat/test-async.R
+++ b/tests/testthat/test-async.R
@@ -276,3 +276,14 @@ test_that("can await-assign with `=` (#29)", {
   })
   expect_equal(wait_for(fn()), 2)
 })
+
+test_that("async function returns invisibly (#46)", {
+  out <- NULL
+  fn <- async(function() {
+    for (i in 1:3) {
+      out <<- c(out, i)
+      await(i)
+    }
+  })
+  expect_invisible(fn())
+})

--- a/tests/testthat/test-generator.R
+++ b/tests/testthat/test-generator.R
@@ -316,3 +316,16 @@ test_that("can yield-assign with `=` (#29)", {
   i()
   expect_equal(i("bar"), "bar")
 })
+
+test_that("stepping into generators returns visibly (#46)", {
+  generate_abc <- generator(function() {
+    yield("a")
+    yield("b")
+    "c"
+  })
+  abc <- generate_abc()
+  expect_visible(abc())
+  expect_visible(abc())
+  expect_visible(abc())
+  expect_visible(abc())
+})


### PR DESCRIPTION
This PR closes #46 so that returned promises objects are not printed. Includes a unit test.