### PR TITLE
Ignore return values of generators

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@
   are now cleaned up when terminated early, either because of an
   error or because of a `break` (#52).
 
+* Implicit and explicit return values of generators are no longer
+  yielded. This is consistent with Javascript and Python and simplifies
+  certain idioms (#51).
+
 * Generators and async functions assigned in namespaces no
   longer produce R CMD check notes about visible bindings (#40).
 

--- a/R/generator.R
+++ b/R/generator.R
@@ -29,16 +29,18 @@
 #' @export
 #' @examples
 #' # A generator statement creates a generator factory. The
-#' # following generator yields two times and then returns `"c"`:
+#' # following generator yields three times and then returns `"d"`.
+#' # Only the yielded values are visible to the callers.
 #' generate_abc <- generator(function() {
 #'   yield("a")
 #'   yield("b")
-#'   "c"
+#'   yield("c")
+#'   "d"
 #' })
 #'
-#' # Or equivalently:
+#' # Equivalently:
 #' generate_abc <- generator(function() {
-#'   for (x in letters[1:3]) {
+#'   for (x in c("a", "b", "c")) {
 #'     yield(x)
 #'   }
 #' })
@@ -103,6 +105,7 @@ generator <- function(fn) {
   assert_lambda(substitute(fn))
   generator0(fn)
 }
+
 #' @rdname generator
 #' @param expr A yielding expression.
 #' @export
@@ -110,6 +113,7 @@ gen <- function(expr) {
   fn <- new_function(NULL, substitute(expr), caller_env())
   generator0(fn)()
 }
+
 generator0 <- function(fn, type = "generator") {
   state_machine <- NULL
   fmls <- formals(fn)

--- a/R/parser.R
+++ b/R/parser.R
@@ -568,7 +568,7 @@ strip_explicit_return <- function(expr) {
 }
 return_call <- function(info) {
   if (is_null(info$async_ops)) {
-    quote(return(last_value()))
+    quote(return(exhausted()))
   } else {
     quote(return(as_promise(last_value())))
   }
@@ -996,8 +996,8 @@ try_catch_states <- function(preamble,
   depth <- machine_depth(counter)
   try_catch_depth <- depth + 1L
 
-  # Handlers can't be evaluated until runtime. We store them in a list
-  # dynamically.
+  # Handlers can't be evaluated until runtime. We store their expressions in a
+  # list. They are evaluated when the user enters the `tryCatch()` state.
   handler_body <- expr({
     !!!preamble %&&% list(user_call(preamble))
     handlers[[!!try_catch_depth]] <- user(base::list(!!!handlers_exprs))

--- a/man/generator.Rd
+++ b/man/generator.Rd
@@ -38,16 +38,18 @@ protocol such as \code{\link[=loop]{loop()}} and \code{\link[=collect]{collect()
 }
 \examples{
 # A generator statement creates a generator factory. The
-# following generator yields two times and then returns `"c"`:
+# following generator yields three times and then returns `"d"`.
+# Only the yielded values are visible to the callers.
 generate_abc <- generator(function() {
   yield("a")
   yield("b")
-  "c"
+  yield("c")
+  "d"
 })
 
-# Or equivalently:
+# Equivalently:
 generate_abc <- generator(function() {
-  for (x in letters[1:3]) {
+  for (x in c("a", "b", "c")) {
     yield(x)
   }
 })

--- a/tests/testthat/_snaps/generator.md
+++ b/tests/testthat/_snaps/generator.md
@@ -28,7 +28,7 @@
               state[[1L]] <- 3L
           }, `3` = {
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -64,7 +64,7 @@
               state[[1L]] <- 3L
           }, `3` = {
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())

--- a/tests/testthat/_snaps/parser-block.md
+++ b/tests/testthat/_snaps/parser-block.md
@@ -21,7 +21,7 @@
               state[[1L]] <- 3L
           }, `3` = {
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -60,7 +60,7 @@
                   "after2"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -93,7 +93,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -141,7 +141,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -187,7 +187,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -222,7 +222,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -251,7 +251,7 @@
               state[[1L]] <- 3L
           }, `3` = {
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -291,7 +291,7 @@
               state[[1L]] <- 5L
           }, `5` = {
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -336,7 +336,7 @@
                   "after2"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -377,7 +377,7 @@
                   "after2"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -416,7 +416,7 @@
                   "after2"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -481,7 +481,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -520,7 +520,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -559,7 +559,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())

--- a/tests/testthat/_snaps/parser-if.md
+++ b/tests/testthat/_snaps/parser-if.md
@@ -83,7 +83,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -174,7 +174,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -271,7 +271,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -347,7 +347,7 @@
                       "if-after"
                   })
                   exhausted <- TRUE
-                  return(last_value())
+                  return(exhausted())
               }, `4` = {
                   break
               })
@@ -367,7 +367,7 @@
                       "foo"
                   })
                   exhausted <- TRUE
-                  return(last_value())
+                  return(exhausted())
               }, `2` = {
                   break
               })
@@ -441,7 +441,7 @@
                       state[[3L]] <- 3L
                   }, `3` = {
                       exhausted <- TRUE
-                      return(last_value())
+                      return(exhausted())
                   }, `4` = {
                       break
                   })
@@ -476,7 +476,7 @@
                       "foo"
                   })
                   exhausted <- TRUE
-                  return(last_value())
+                  return(exhausted())
               }, `2` = {
                   break
               })
@@ -589,7 +589,7 @@
                         "if-2-after"
                       })
                       exhausted <- TRUE
-                      return(last_value())
+                      return(exhausted())
                   }, `4` = {
                       break
                   })
@@ -624,7 +624,7 @@
                       FALSE
                   })
                   exhausted <- TRUE
-                  return(last_value())
+                  return(exhausted())
               }, `2` = {
                   break
               })
@@ -694,7 +694,7 @@
                       "if-after"
                   })
                   exhausted <- TRUE
-                  return(last_value())
+                  return(exhausted())
               }, `4` = {
                   break
               })
@@ -725,7 +725,7 @@
                       "else-after"
                   })
                   exhausted <- TRUE
-                  return(last_value())
+                  return(exhausted())
               }, `4` = {
                   break
               })
@@ -844,7 +844,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -932,7 +932,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -1026,7 +1026,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -1120,7 +1120,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -1209,7 +1209,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -1430,7 +1430,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())

--- a/tests/testthat/_snaps/parser-loop.md
+++ b/tests/testthat/_snaps/parser-loop.md
@@ -47,7 +47,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -90,7 +90,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -139,7 +139,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -217,7 +217,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -280,7 +280,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -329,7 +329,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -418,7 +418,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -1159,7 +1159,7 @@
               state[[1L]] <- 5L
           }, `5` = {
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -1325,7 +1325,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -1532,7 +1532,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -1682,7 +1682,7 @@
                   repeat switch(state[[3L]], `1` = {
                       user(1L)
                       exhausted <- TRUE
-                      return(last_value())
+                      return(exhausted())
                   }, `2` = {
                       break
                   })
@@ -1874,7 +1874,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -2020,7 +2020,7 @@
                   "after"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())

--- a/tests/testthat/_snaps/parser.md
+++ b/tests/testthat/_snaps/parser.md
@@ -10,7 +10,7 @@
           repeat switch(state[[1L]], `1` = {
               user("foo")
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -28,7 +28,7 @@
           repeat switch(state[[1L]], `1` = {
               user("foo")
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -53,7 +53,7 @@
               state[[1L]] <- 3L
           }, `3` = {
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -78,7 +78,7 @@
               state[[1L]] <- 3L
           }, `3` = {
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -102,7 +102,7 @@
                   "bar"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -133,7 +133,7 @@
               state[[1L]] <- 3L
           }, `3` = {
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -157,7 +157,7 @@
                   "value"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -192,7 +192,7 @@
                   "bar"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -227,7 +227,7 @@
                   "bar"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -314,7 +314,7 @@
                   body2()
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -369,7 +369,7 @@
                   body4()
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -447,7 +447,7 @@
                   body4()
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -844,7 +844,7 @@
                   body2()
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -932,7 +932,7 @@
                   body2()
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -1036,7 +1036,7 @@
                   body2()
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -1079,7 +1079,7 @@
                   state[[2L]] <- 3L
               }, `3` = {
                   exhausted <- TRUE
-                  return(last_value())
+                  return(exhausted())
               }, `4` = {
                   break
               })
@@ -1099,7 +1099,7 @@
                       "else"
                   })
                   exhausted <- TRUE
-                  return(last_value())
+                  return(exhausted())
               }, `2` = {
                   break
               })
@@ -1323,7 +1323,7 @@
                   body2()
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -1482,7 +1482,7 @@
                   body3()
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -1601,7 +1601,7 @@
                   body4()
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -1784,7 +1784,7 @@
                   body2()
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -1807,7 +1807,7 @@
           }, `2` = {
               .last_value <- user_env[["x"]] <- if (missing(arg)) NULL else arg
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -1834,7 +1834,7 @@
           }, `2` = {
               .last_value <- user_env[["x"]] <- if (missing(arg)) NULL else arg
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -1852,7 +1852,7 @@
           repeat switch(state[[1L]], `1` = {
               user(tryCatch(foo()))
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -1895,7 +1895,7 @@
                         state[[2L]] <- 3L
                       }, `3` = {
                         exhausted <- TRUE
-                        return(last_value())
+                        return(exhausted())
                       }, `4` = {
                         break
                       })
@@ -1913,7 +1913,7 @@
                   last_value()
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -1977,7 +1977,7 @@
                   "value"
               })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -1995,7 +1995,7 @@
           repeat switch(state[[1L]], `1` = {
               user(withCallingHandlers(expr))
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())
@@ -2054,7 +2054,7 @@
                       last_value()
                   })
               exhausted <- TRUE
-              return(last_value())
+              return(exhausted())
           })
           exhausted <- TRUE
           invisible(exhausted())


### PR DESCRIPTION
We now return `exhausted()` instead of `last_value()` in generators. Fixes #51.

This is different from the JS behaviour where an iterator is allowed to return a value with the exhaustion sentinel, e.g. `{value: "something", done: true}`. In contrast we discard the return value entirely. This is consistent with our sentinel model and simpler. I may be missing a use case for returning the value as in JS but I don't think we're missing out much?

The generator state machines still keep track of last values because this is used in async functions where we do want to return that value.