### PR TITLE
Run `on.exit()` expressions when loops break early

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # coro (development version)
 
+* Iterator functions are now allowed to have a `close` argument.
+  If they do, they will be called with a `close = TRUE` value
+  when iteration is terminated early. This gives the opportunity
+  to clean up resources.
+
+* Generators now run `on.exit()` expressions when they are closed.
+
+* Iterators managed by `coro::loop()` and by generator `for` loops
+  are now cleaned up when terminated early, either because of an
+  error or because of a `break` (#52).
+
 * Generators and async functions assigned in namespaces no
   longer produce R CMD check notes about visible bindings (#40).
 

--- a/R/generator.R
+++ b/R/generator.R
@@ -193,8 +193,9 @@ generator0 <- function(fn, type = "generator") {
 
         if (close) {
           # Run in environment where user exits are installed. Unlike in the
-          # state machine path, we don't disable them before exiting so they
-          # will run.
+          # state machine path, where these expressions are meant to only run in
+          # case of unexpected exits, we don't disable them before exiting so
+          # they will actually run here.
           evalq(envir = user_env,
             base::evalq(envir = rlang::wref_key(!!weak_env), {
               env_poke_exits(user_env, exits)

--- a/R/iterator-collect.R
+++ b/R/iterator-collect.R
@@ -64,6 +64,10 @@ loop <- function(loop) {
   iterator <- as_iterator(eval_bare(node_cadr(args), env))
   body <- node_cadr(node_cdr(args))
 
+  if (has_close(iterator)) {
+    defer(iterator(close = TRUE))
+  }
+
   elt <- NULL
   advance <- function() !is_exhausted(elt <<- iterator())
   update <- function() env[[var]] <- elt

--- a/R/iterator-collect.R
+++ b/R/iterator-collect.R
@@ -64,9 +64,7 @@ loop <- function(loop) {
   iterator <- as_iterator(eval_bare(node_cadr(args), env))
   body <- node_cadr(node_cdr(args))
 
-  if (has_close(iterator)) {
-    defer(iterator(close = TRUE))
-  }
+  defer(iter_close(iterator))
 
   elt <- NULL
   advance <- function() !is_exhausted(elt <<- iterator())

--- a/R/iterator.R
+++ b/R/iterator.R
@@ -144,6 +144,8 @@ as_iterator.python.builtin.object <- function(x) {
   function() reticulate::iter_next(x, exhausted())
 }
 
-has_close <- function(iter) {
-  "close" %in% names(formals(iter))
+iter_close <- function(iter) {
+  if ("close" %in% names(formals(iter))) {
+    iter(close = TRUE)
+  }
 }

--- a/R/iterator.R
+++ b/R/iterator.R
@@ -27,6 +27,10 @@
 #'   drivers must check for the presence of the argument. If not present,
 #'   the iterator can be dropped without cleanup.
 #'
+#'   An iterator passed `close = TRUE` must return `coro::exhausted()` and
+#'   once closed, an iterator must return `coro::exhausted()` when called
+#'   again.
+#'
 #' ```{r}
 #' iterator <- as_iterator(1:3)
 #'

--- a/R/iterator.R
+++ b/R/iterator.R
@@ -143,3 +143,7 @@ as_iterator.python.builtin.object <- function(x) {
   x <- reticulate::as_iterator(x)
   function() reticulate::iter_next(x, exhausted())
 }
+
+has_close <- function(iter) {
+  "close" %in% names(formals(iter))
+}

--- a/R/iterator.R
+++ b/R/iterator.R
@@ -16,6 +16,17 @@
 #'   invokations must consistently return `coro::exhausted()` or
 #'   `as.symbol(".__exhausted__.")`.
 #'
+#' - The iterator function may have a `close` argument taking boolean
+#'   values. When passed a `TRUE` value, it indicates early termination
+#'   and the iterator is given the opportunity to clean up resources.
+#'
+#'   Cleanup must only be performed once, even if the iterator is called
+#'   multiple times with `close = TRUE`.
+#'
+#'   An iterator is allowed to not have any `close` argument. Iterator
+#'   drivers must check for the presence of the argument. If not present,
+#'   the iterator can be dropped without cleanup.
+#'
 #' ```{r}
 #' iterator <- as_iterator(1:3)
 #'

--- a/R/parser.R
+++ b/R/parser.R
@@ -882,9 +882,10 @@ for_states <- function(preamble,
     nested_states <- condition_state(condition, nested_counter)
   }
 
-  cleanup <- expr(
+  cleanup <- expr({
+    iter_close(iterators[[!!loop_depth]])
     iterators[[!!loop_depth]] <- NULL
-  )
+  })
 
   loop_states(
     preamble = preamble,

--- a/R/step-reduce.R
+++ b/R/step-reduce.R
@@ -317,6 +317,9 @@ iter_reduce_impl <- function(.x, .f, ..., .init, .left = TRUE) {
     abort("Can't right-reduce with an iterator.")
   }
 
+  # TODO: How do we close transducers?
+  defer(iter_close(.x))
+
   .f <- as_function(.f)
 
   out <- NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -106,3 +106,8 @@ zap_env <- function(x) {
   env_poke(env, lhs, value, inherit = TRUE, create = FALSE)
   invisible(value)
 }
+
+defer <- function(expr, env = caller_env(), after = FALSE) {
+  thunk <- as.call(list(function() expr))
+  do.call(on.exit, list(thunk, TRUE, after), envir = env)
+}

--- a/man/iterator.Rd
+++ b/man/iterator.Rd
@@ -35,6 +35,10 @@ multiple times with \code{close = TRUE}.
 An iterator is allowed to not have any \code{close} argument. Iterator
 drivers must check for the presence of the argument. If not present,
 the iterator can be dropped without cleanup.
+
+An iterator passed \code{close = TRUE} must return \code{coro::exhausted()} and
+once closed, an iterator must return \code{coro::exhausted()} when called
+again.
 }
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{iterator <- as_iterator(1:3)

--- a/man/iterator.Rd
+++ b/man/iterator.Rd
@@ -25,6 +25,16 @@ exhaustion to the caller.
 \item Once an iterator has signalled exhaustion, all subsequent
 invokations must consistently return \code{coro::exhausted()} or
 \code{as.symbol(".__exhausted__.")}.
+\item The iterator function may have a \code{close} argument taking boolean
+values. When passed a \code{TRUE} value, it indicates early termination
+and the iterator is given the opportunity to clean up resources.
+
+Cleanup must only be performed once, even if the iterator is called
+multiple times with \code{close = TRUE}.
+
+An iterator is allowed to not have any \code{close} argument. Iterator
+drivers must check for the presence of the argument. If not present,
+the iterator can be dropped without cleanup.
 }
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{iterator <- as_iterator(1:3)

--- a/tests/testthat/_snaps/async.md
+++ b/tests/testthat/_snaps/async.md
@@ -284,11 +284,17 @@
                       })
                       state[[3L]] <- 1L
                   })
-                  iterators[[3L]] <- NULL
+                  {
+                      iter_close(iterators[[3L]])
+                      iterators[[3L]] <- NULL
+                  }
                   length(state) <- 2L
                   state[[2L]] <- 1L
               })
-              iterators[[2L]] <- NULL
+              {
+                  iter_close(iterators[[2L]])
+                  iterators[[2L]] <- NULL
+              }
               length(state) <- 1L
               break
           })

--- a/tests/testthat/_snaps/parser-loop.md
+++ b/tests/testthat/_snaps/parser-loop.md
@@ -1404,7 +1404,10 @@
               }, `2` = {
                   break
               })
-              iterators[[2L]] <- NULL
+              {
+                  iter_close(iterators[[2L]])
+                  iterators[[2L]] <- NULL
+              }
               length(state) <- 1L
               break
           })
@@ -1451,7 +1454,10 @@
                   .last_value <- if (missing(arg)) NULL else arg
                   state[[2L]] <- 1L
               })
-              iterators[[2L]] <- NULL
+              {
+                  iter_close(iterators[[2L]])
+                  iterators[[2L]] <- NULL
+              }
               length(state) <- 1L
               break
           })
@@ -1515,7 +1521,10 @@
                   })
                   state[[2L]] <- 1L
               })
-              iterators[[2L]] <- NULL
+              {
+                  iter_close(iterators[[2L]])
+                  iterators[[2L]] <- NULL
+              }
               length(state) <- 1L
               state[[1L]] <- 3L
           }, `3` = {
@@ -1628,7 +1637,10 @@
                   })
                   state[[2L]] <- 1L
               })
-              iterators[[2L]] <- NULL
+              {
+                  iter_close(iterators[[2L]])
+                  iterators[[2L]] <- NULL
+              }
               length(state) <- 1L
               break
           })

--- a/tests/testthat/_snaps/parser.md
+++ b/tests/testthat/_snaps/parser.md
@@ -1644,7 +1644,10 @@
                   .last_value <- if (missing(arg)) NULL else arg
                   state[[2L]] <- 1L
               })
-              iterators[[2L]] <- NULL
+              {
+                  iter_close(iterators[[2L]])
+                  iterators[[2L]] <- NULL
+              }
               length(state) <- 1L
               break
           })
@@ -1708,11 +1711,17 @@
                       .last_value <- if (missing(arg)) NULL else arg
                       state[[3L]] <- 1L
                   })
-                  iterators[[3L]] <- NULL
+                  {
+                      iter_close(iterators[[3L]])
+                      iterators[[3L]] <- NULL
+                  }
                   length(state) <- 2L
                   state[[2L]] <- 1L
               })
-              iterators[[2L]] <- NULL
+              {
+                  iter_close(iterators[[2L]])
+                  iterators[[2L]] <- NULL
+              }
               length(state) <- 1L
               break
           })
@@ -1764,7 +1773,10 @@
                   .last_value <- if (missing(arg)) NULL else arg
                   state[[2L]] <- 1L
               })
-              iterators[[2L]] <- NULL
+              {
+                  iter_close(iterators[[2L]])
+                  iterators[[2L]] <- NULL
+              }
               length(state) <- 1L
               state[[1L]] <- 3L
           }, `3` = {
@@ -2197,7 +2209,10 @@
                   .last_value <- if (missing(arg)) NULL else arg
                   state[[2L]] <- 1L
               })
-              iterators[[2L]] <- NULL
+              {
+                  iter_close(iterators[[2L]])
+                  iterators[[2L]] <- NULL
+              }
               length(state) <- 1L
               break
           })

--- a/tests/testthat/test-async.R
+++ b/tests/testthat/test-async.R
@@ -320,6 +320,10 @@ test_that("async function returns invisibly (#46)", {
 
 test_that("async functions do not cause CMD check notes (#40)", {
   skip_on_cran()
+    invisible(compiler::cmpfun(
+      async(function() NULL),
+      options = list(suppressAll = FALSE)
+    ))
   expect_silent(
     invisible(compiler::cmpfun(
       async(function() NULL),

--- a/tests/testthat/test-async.R
+++ b/tests/testthat/test-async.R
@@ -181,8 +181,8 @@ test_that("Iterators are cleaned up from most nested to least nested", {
     for (i in await_each(g1())) {
       for (j in await_each(g2())) {
         yield(c(i, j))
+        stop("foo")
       }
-      stop("foo")
     }
   })
 

--- a/tests/testthat/test-async.R
+++ b/tests/testthat/test-async.R
@@ -162,6 +162,36 @@ test_that("for loops support await_each()", {
   }))
 })
 
+test_that("Iterators are cleaned up from most nested to least nested", {
+  called <- NULL
+
+  g1 <- coro::async_generator(function() {
+    on.exit(called <<- c(called, "g1"))
+    yield(1)
+    yield(2)
+  })
+  g2 <- coro::async_generator(function() {
+    on.exit(called <<- c(called, "g2"))
+    yield(1)
+    yield(2)
+  })
+
+  h <- coro::async_generator(function() {
+    on.exit(called <<- c(called, "h"))
+    for (i in await_each(g1())) {
+      for (j in await_each(g2())) {
+        yield(c(i, j))
+      }
+      stop("foo")
+    }
+  })
+
+  expect_error(
+    wait_for(async_collect(h()))
+  )
+  expect_equal(called, c("g2", "g1", "h"))
+})
+
 test_that("await_each() can't be used in generators", {
   expect_error(generator(function() for (x in await_each(i)) NULL)()(), "non-async generator")
 })

--- a/tests/testthat/test-generator.R
+++ b/tests/testthat/test-generator.R
@@ -339,3 +339,34 @@ test_that("generators do not cause CMD check notes (#40)", {
     ))
   )
 })
+
+test_that("on.exit is called when loop breaks early (#52)", {
+  called <- NULL
+  g <- coro::generator(function() {
+    on.exit(called <<- TRUE)
+    yield(1)
+    yield(2)
+  })
+
+  called <- FALSE
+  expect_error(
+    coro::loop(for (i in g()) {
+      stop("boom!")
+    })
+  )
+  expect_true(called)
+
+  called <- FALSE
+  iter <- g()
+  iter()
+  expect_false(called)
+
+  iter(close = TRUE)
+  expect_true(called)
+
+  # Only called once
+  called <- FALSE
+  iter()
+  iter(close = TRUE)
+  expect_false(called)
+})

--- a/tests/testthat/test-generator.R
+++ b/tests/testthat/test-generator.R
@@ -453,9 +453,11 @@ test_that("disabled generators only clean up once", {
   called <- NULL
   g <- coro::generator(function() {
     on.exit(called <<- c(called, TRUE))
-    stop("foo")
     yield(1)
+    stop("foo")
   })()
+
+  expect_equal(g(), 1)
 
   expect_error(g(), "foo")
   expect_equal(called, TRUE)

--- a/tests/testthat/test-generator.R
+++ b/tests/testthat/test-generator.R
@@ -381,7 +381,6 @@ test_that("for loops in generators close their iterators (#52)", {
   h <- coro::generator(function() {
     for (i in g()) {
       yield(i)
-      # break
       stop("foo")
     }
   })
@@ -394,8 +393,29 @@ test_that("for loops in generators close their iterators (#52)", {
   # expect_true(called)
 
   called <- FALSE
-  expect_error(loop(for (i in h()) {
-    print(i)
-  }))
+  expect_error(loop(for (i in h()) {}))
+  expect_true(called)
+})
+
+test_that("for loops in generators close their iterators - break (#52)", {
+  called <- NULL
+  g <- coro::generator(function() {
+    on.exit(called <<- TRUE)
+    yield(1)
+    yield(2)
+  })
+  h <- coro::generator(function() {
+    for (i in g()) {
+      yield(i)
+      break
+    }
+  })
+
+  called <- FALSE
+  collect(h())
+  expect_true(called)
+
+  called <- FALSE
+  loop(for (i in h()) {})
   expect_true(called)
 })

--- a/tests/testthat/test-generator.R
+++ b/tests/testthat/test-generator.R
@@ -389,8 +389,7 @@ test_that("for loops in generators close their iterators (#52)", {
   expect_error(
     collect(h())
   )
-  # FIXME
-  # expect_true(called)
+  expect_true(called)
 
   called <- FALSE
   expect_error(loop(for (i in h()) {}))

--- a/tests/testthat/test-generator.R
+++ b/tests/testthat/test-generator.R
@@ -434,6 +434,7 @@ test_that("Iterators are cleaned up from most nested to least nested", {
   })
 
   h <- coro::generator(function() {
+    on.exit(called <<- c(called, "h"))
     for (i in g1()) {
       for (j in g2()) {
         yield(c(i, j))
@@ -445,5 +446,5 @@ test_that("Iterators are cleaned up from most nested to least nested", {
   expect_error(
     collect(h())
   )
-  expect_equal(called, c("g2", "g1"))
+  expect_equal(called, c("g2", "g1", "h"))
 })


### PR DESCRIPTION
Fixes #52.

A generator is allowed to register exit handlers via `on.exit()` or similar (e.g. `withr::defer()`). Currently these exit expressions only run when the generator _returns_, or on unexpected exit such as an error happening while the generator is executing. They are _not_ run when an iteration driver decides to cancel the iteration, or is interrupted by an unexpected exit. E.g.:

```r
g <- coro::generator(function() {
  on.exit(cat("cleanup\n"))
  yield(1)
  yield(2)
})

# Cleanup not run
coro::loop(for (i in g()) {
  break
})

# Cleanup not run
coro::loop(for (i in g()) {
  stop("foo")
})
```

To fix this:

- We introduce the notion of closing an iterator. A closable iterator has a `close` argument in its formals. When it does, coro loop drivers (either `coro::loop()` or `for` loops inside generators) call the iterator with `close = TRUE` when iteration has finished or is interrupted. The iterator can then clean up resources.

  A closable iterator should ignore any further call with `close = TRUE` as coro and other iteration drivers are allowed to do that multiple times to simplify their implementations. They are also allowed to call an exhausted iterator with `close = TRUE`, even though resource cleanup should have been accomplished already.

- Generators now produce iterators with a `close` argument. Closing a generator has two effects: First, all iterators in active `for` loops are closed, from the most nested to the least nested one. This triggers a cleanup chain across generators/iterators. Second, the generator's own `on.exit()` expressions are run.

- `coro::loop()` now closes its iterator on exit.

The same applies to async generators.

Note that Python also closes generators on garbage collection. I decided not to do that because resource cleanup should be hierarchical. Instead, it's up to the generator caller to ensure proper closing of their generator. The easiest way is to use `coro::loop()`. Javascript doesn't close on GC either, see https://esdiscuss.org/topic/garbage-collection-in-generators for some discussion.
