### PR TITLE
Update docs referencing old exhausted sentinel value

### DIFF
--- a/R/iterator.R
+++ b/R/iterator.R
@@ -8,9 +8,9 @@
 #' - Calling the function advances the iterator. The new value is
 #'   returned.
 #'
-#' - When the iterator is exhausted and there are no more elements to
-#'   return, the symbol `quote(exhausted)` is returned. This signals
-#'   exhaustion to the caller.
+#' - When the iterator is exhausted and there are no more elements to return,
+#'   `coro::exhausted()` or (equivalently) `as.symbol(".__exhausted__.")` is
+#'   returned. This signals exhaustion to the caller.
 #'
 #' - Once an iterator has signalled exhaustion, all subsequent
 #'   invokations must consistently return `coro::exhausted()` or

--- a/man/iterator.Rd
+++ b/man/iterator.Rd
@@ -19,9 +19,9 @@ protocol:
 \itemize{
 \item Calling the function advances the iterator. The new value is
 returned.
-\item When the iterator is exhausted and there are no more elements to
-return, the symbol \code{quote(exhausted)} is returned. This signals
-exhaustion to the caller.
+\item When the iterator is exhausted and there are no more elements to return,
+\code{coro::exhausted()} or (equivalently) \code{as.symbol(".__exhausted__.")} is
+returned. This signals exhaustion to the caller.
 \item Once an iterator has signalled exhaustion, all subsequent
 invokations must consistently return \code{coro::exhausted()} or
 \code{as.symbol(".__exhausted__.")}.


### PR DESCRIPTION
This is a minor documentation fix.

`?coro::exhausted` currently includes this text:
```
        • When the iterator is exhausted and there are no more elements
          to return, the symbol 'quote(exhausted)' is returned. This
          signals exhaustion to the caller.

        • Once an iterator has signalled exhaustion, all subsequent
          invokations must consistently return 'coro::exhausted()' or
          'as.symbol(".__exhausted__.")'.
```
The former bullet point references the old exhausted sentinel value.  This PR updates the docs to reference the current sentinel value.