### PR TITLE
Fix roxygen2 8.0.0 link-resolution warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,4 +35,4 @@ Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+Config/roxygen2/version: 8.0.0

--- a/R/iterator-adapt.R
+++ b/R/iterator-adapt.R
@@ -7,14 +7,14 @@
 #' commit to the transducer approach. Feedback welcome._
 #'
 #' `iter_adapt()` takes an iterator `iter` and a list of
-#' [Transformation steps][steps]. It returns an iterator that returns
+#' transformation steps. It returns an iterator that returns
 #' transformed values.
 #'
 #' `async_adapt()` does the same for async iterators, i.e. functions
 #' that returns an awaitable value.
 #'
 #' @param iter An [iterator].
-#' @param steps,... [Transformation steps][steps]. These dots are taken with
+#' @param steps,... Transformation steps. These dots are taken with
 #'   implicit splicing of lists and passed to `compose()`.
 #'
 #' @seealso [loop()] for looping over iterator values with a `for`

--- a/R/step-builder.R
+++ b/R/step-builder.R
@@ -5,7 +5,7 @@
 #'
 #' `along_builder()` and `poke_into_builder()` are builder functions,
 #' i.e. reducer functions that construct an output when reduced with
-#' [purrr::reduce()] or [reduce_steps()]. While `along_builder()`
+#' [purrr::reduce()] or `reduce_steps()`. While `along_builder()`
 #' duplicates its input, `poke_into_builder()` fills the supplied
 #' input in place. The latter is only meant for experience users as
 #' this mutation can cause unexpected side effects. You should only
@@ -19,9 +19,9 @@
 #' by vector growing and shrinking, supply a vector whose size matches
 #' exactly the final output.
 #'
-#' The builder functions can be combined with [transformation
-#' steps][steps] to provide interesting functionality. See the
-#' [take()] variants for higher-level functions.
+#' The builder functions can be combined with transformation
+#' steps to provide interesting functionality. See the
+#' `iter_take()` variants for higher-level functions.
 #'
 #' @param along A vector that will be safely duplicated before
 #'   filling.
@@ -29,7 +29,7 @@
 #'   output has a different length than `to`, it will still be copied
 #'   when grown and/or shrunk.
 #'
-#' @seealso [reduce_steps()], [steps]
+#' @seealso `reduce_steps()`, transformation steps
 #' @examples
 #' # Let's discard all pair elements during reduction to make the
 #' # examples a bit more interesting

--- a/R/step-reduce.R
+++ b/R/step-reduce.R
@@ -16,8 +16,8 @@
 #' abstract and it takes some time understand how they work and how to
 #' write one. However most of the time you shouldn't have to use
 #' `reduce_steps()` or write your own transformation step. You will
-#' typically use existing steps provided in coro (like [iter_map()]
-#' and [iter_discard()]) with user-friendly wrappers such as
+#' typically use existing steps provided in coro (like `iter_map()`
+#' and `iter_discard()`) with user-friendly wrappers such as
 #' `iter_adapt()`.
 #'
 #' `reduce_steps()` and thus all functions based on it support coro
@@ -120,7 +120,7 @@
 #'   builder function is called without argument to get an initial
 #'   value.
 #'
-#' @seealso [steps], [along_builder()]
+#' @seealso transformation steps, `along_builder()`
 #' @examples
 #' # Let's create a chain of transformation. Let's start with the very
 #' # last step, the builder function.

--- a/R/step.R
+++ b/R/step.R
@@ -4,7 +4,7 @@
 #' @description
 #'
 #' Transformation steps can be chained together to modify the
-#' behaviour of an iterator (see [iter_adapt()]).
+#' behaviour of an iterator (see `iter_adapt()`).
 #'
 #' * `iter_map()` applies a function `.f` over all inputs.
 #'

--- a/man/coro-package.Rd
+++ b/man/coro-package.Rd
@@ -20,6 +20,11 @@ Useful links:
 \author{
 \strong{Maintainer}: Lionel Henry \email{lionel@posit.co}
 
+Authors:
+\itemize{
+  \item Lionel Henry \email{lionel@posit.co}
+}
+
 Other contributors:
 \itemize{
   \item Posit Software, PBC [copyright holder, funder]


### PR DESCRIPTION
## Summary
Updated documentation with the latest roxygen2 (8.0.0) via `devtools::document()`, which surfaced 14 new "Could not resolve link to topic" warnings. These were all markdown links (e.g. `[steps]`, `[reduce_steps()]`, `[iter_adapt()]`) pointing at internal helper functions documented with `@noRd`, so no Rd topic exists for roxygen2 to link to. Replaced these links with plain code spans in `R/iterator-adapt.R`, `R/step-builder.R`, `R/step-reduce.R`, and `R/step.R`. `DESCRIPTION` and `man/coro-package.Rd` were regenerated as a side effect of running the newer roxygen2/devtools (adds `Config/roxygen2/version` and expands the authors list in the package Rd).

## Verification
Ran `devtools::document()` before and after: previously produced 14 warnings, now completes with zero warnings.